### PR TITLE
convert git://github.com SRC_URIs to use https

### DIFF
--- a/recipes-security/audit/audit_3.0.1.bb
+++ b/recipes-security/audit/audit_3.0.1.bb
@@ -7,7 +7,7 @@ SECTION = "base"
 LICENSE = "GPLv2+ & LGPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 
-SRC_URI = "git://github.com/linux-audit/${BPN}-userspace.git;branch=master \
+SRC_URI = "git://github.com/linux-audit/${BPN}-userspace.git;branch=master;protocol=https \
            file://Fixed-swig-host-contamination-issue.patch \
            file://auditd \
            file://auditd.service \

--- a/recipes-security/refpolicy/refpolicy_git.inc
+++ b/recipes-security/refpolicy/refpolicy_git.inc
@@ -1,6 +1,6 @@
 PV = "2.20210203+git${SRCPV}"
 
-SRC_URI = "git://github.com/SELinuxProject/refpolicy.git;protocol=git;branch=master;name=refpolicy;destsuffix=refpolicy"
+SRC_URI = "git://github.com/SELinuxProject/refpolicy.git;protocol=https;branch=master;name=refpolicy;destsuffix=refpolicy"
 
 SRCREV_refpolicy ?= "1167739da1882f9c89281095d2595da5ea2d9d6b"
 

--- a/recipes-security/selinux/selinux_common.inc
+++ b/recipes-security/selinux/selinux_common.inc
@@ -1,6 +1,6 @@
 HOMEPAGE = "https://github.com/SELinuxProject"
 
-SRC_URI = "git://github.com/SELinuxProject/selinux.git"
+SRC_URI = "git://github.com/SELinuxProject/selinux.git;protocol=https"
 SRCREV = "cf853c1a0c2328ad6c62fb2b2cc55d4926301d6b"
 
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>\d+(\.\d+)+)"

--- a/recipes-security/setools/setools_4.4.0.bb
+++ b/recipes-security/setools/setools_4.4.0.bb
@@ -11,7 +11,7 @@ LICENSE = "GPLv2 & LGPLv2.1"
 BBCLASSEXTEND = "native nativesdk "
 
 S = "${WORKDIR}/git"
-SRC_URI = "git://github.com/SELinuxProject/${BPN}.git;branch=4.4 \
+SRC_URI = "git://github.com/SELinuxProject/${BPN}.git;branch=4.4;protocol=https \
            file://setools4-fixes-for-cross-compiling.patch \
 "
 


### PR DESCRIPTION
Github is moving to deprecate the git:// protocol for repo access. Use a
modified version of the upstream covert-srcuris.py script to find and
fixup github source URIs in-bulk.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

# Testing
Ran the `do_fetch` tasks of `packagefeed-ni-core` and confirmed that bitbake does not report any recipes as using a `git://github.com` URI.

@ni/rtos