### PR TITLE
initscripts: fix incompatibility with read-only-rootfs

### DIFF
--- a/recipes-core/initscripts/initscripts-1.0_selinux.inc
+++ b/recipes-core/initscripts/initscripts-1.0_selinux.inc
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-do_install:append () {
+do_restore_context() {
 	cat <<-EOF >> ${D}${sysconfdir}/init.d/populate-volatile.sh
 touch /var/log/lastlog
 test ! -x /sbin/restorecon || /sbin/restorecon -iRF /var/volatile/ /var/lib /run \
@@ -8,4 +8,9 @@ test ! -x /sbin/restorecon || /sbin/restorecon -iRF /var/volatile/ /var/lib /run
 EOF
 	sed -i '/mount -n -o remount,$rootmode/i\test ! -x /sbin/restorecon || /sbin/restorecon -iRF /run' \
 	    ${D}${sysconfdir}/init.d/checkroot.sh
+}
+
+python __anonymous() {
+    if 'read-only-rootfs' not in d.getVar('IMAGE_FEATURES'):
+        d.appendVar('do_install', ' do_restore_context;')
 }


### PR DESCRIPTION
When the read-only-rootfs feature (in IMAGE_FEATURES) is enabled, the populate-volatile.sh script runs at build time. This compensates for the fact that certain essential directories and files cannot be created at runtime, since the root filesystem is read-only. This is handled in oe-core's rootfs-postcommands.bbclass, in read_only_rootfs_hook.

However, initscripts-1.0_selinux.inc appends some shell code to populate-volatile.sh considering it will be run in the target, not on the host machine. So, if one uses both read-only-rootfs and selinux (in DISTRO_FEATURES), the recursive call to restorecon is run in the host machine, since populate-volatile.sh is called in build time. This leads to errors such as:

| NOTE: Executing read_only_rootfs_hook ...
| DEBUG: Executing shell function read_only_rootfs_hook
| /sbin/restorecon: Could not read /var/lib/AccountsService/users: Permission denied.
| /sbin/restorecon: Could not read /var/lib/NetworkManager: Permission denied.
| /sbin/restorecon: Could not read /var/lib/bluetooth: Permission denied.
| /sbin/restorecon: Could not read /var/lib/chrony: Permission denied.

As a matter of fact, this scenario is a fair reminder not to call bitbake with sudo.

This change makes sure the append is only performed if the read-only-rootfs feature is not used.